### PR TITLE
Fix poster URLs for new releases collections

### DIFF
--- a/collection_files/better_new_and_old_movie_releases.yml
+++ b/collection_files/better_new_and_old_movie_releases.yml
@@ -13,7 +13,7 @@ collections:
     visible_home: true
     visible_shared: true
     sort_title: "!008_New_Releases"
-    url_poster: https://raw.githubusercontent.com/s0len/meta-manager-config/main/posters/new-releases/New_Movie_Releases_Collection.jpg
+    url_poster: https://raw.githubusercontent.com/s0len/meta-manager-config/main/posters/new-releases/New_Movie_Releases.jpg
 
   Old Movies Just Added: # SMART COLLECTION
     #variables: {your variables}

--- a/collection_files/better_new_and_old_tv_shows_releases.yml
+++ b/collection_files/better_new_and_old_tv_shows_releases.yml
@@ -12,7 +12,7 @@ collections:
     visible_home: true
     visible_shared: true
     sort_title: "!008_New_Releases"
-    url_poster: https://raw.githubusercontent.com/s0len/meta-manager-config/main/posters/new-releases/New_TV_Show_Releases_Collection.jpg
+    url_poster: https://raw.githubusercontent.com/s0len/meta-manager-config/main/posters/new-releases/New_TV_Show_Releases.jpg
 
   Old TV Shows Just Added:
     smart_filter:
@@ -21,7 +21,7 @@ collections:
         episode_added: 30
         any:
           episode_air_date.not: 365
-          label.not: New Release 
+          label.not: New Release
       limit: 250
     summary: Older shows added in the past month. Sorted by Date Added.
     visible_library: true


### PR DESCRIPTION
@s0len Thank you for creating these configs! They look great.

# Fixes

After applying these configs, I noticed that the poster URLs for the `New Movie Releases` and `New TV Show Releases` collections were broken. Looks like the file names were changed to remove `_Collection`. I have updated them in the following files:
- [collection_files/better_new_and_old_movie_releases.yml](https://github.com/s0len/meta-manager-config/compare/main...scottgigawatt:meta-manager-config:main#diff-6935fc7609b2493edac0832e95eb8bb7a54d39d3a94e34c3c2599b0befa95899)
- [collection_files/better_new_and_old_tv_shows_releases.yml](https://github.com/s0len/meta-manager-config/compare/main...scottgigawatt:meta-manager-config:main#diff-c394a13c29f8e62f376b78f5b5d242571675749176a42dc2b3b947efe66cef78)

Looks like my YAML linter also removed a trailing space (hopefully that's OK).