### PR TITLE
Use <<key_encoded>> in overlay URL examples (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Run this once before stacking resolution/audio/studio overlays:
     vertical_offset: 0
     back_width: 1000
     back_height: 1500
-    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/studio-top-left/<<key>>.png
+    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/studio-top-left/<<key_encoded>>.png
     back_color: 00
 - url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/ribbon_awards.yml
 - url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/ribbon_trending.yml
@@ -227,7 +227,7 @@ Run this once before stacking resolution/audio/studio overlays:
     vertical_align: top
     back_width: 1000
     back_height: 1500
-    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/network-top-left/<<key>>.png
+    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/network-top-left/<<key_encoded>>.png
     back_color: 00
 ```
 
@@ -244,7 +244,7 @@ Run this once before stacking resolution/audio/studio overlays:
     vertical_offset: 0
     back_width: 1000
     back_height: 1500
-    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/studio-top-left/<<key>>.png
+    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/studio-top-left/<<key_encoded>>.png
     back_color: 00
 - default: streaming
   template_variables:
@@ -254,7 +254,7 @@ Run this once before stacking resolution/audio/studio overlays:
     vertical_align: top
     back_width: 1000
     back_height: 1500
-    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/streaming-top-left/<<key>>.png
+    url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/streaming-top-left/<<key_encoded>>.png
     back_color: 00
 ```
 

--- a/exampleConfig.yml
+++ b/exampleConfig.yml
@@ -102,7 +102,7 @@ libraries:
           vertical_align: top
           back_width: 1000
           back_height: 1500
-          url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/network-top-left/<<key>>.png 
+          url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/network-top-left/<<key_encoded>>.png 
           back_color: 00 
 
   Anime Series:
@@ -115,7 +115,7 @@ libraries:
           vertical_offset: 0
           back_width: 1000
           back_height: 1500
-          url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/studio-top-left/<<key>>.png
+          url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/overlays/studio-top-left/<<key_encoded>>.png
           back_color: 00
       - pmm: status
         template_variables:


### PR DESCRIPTION
## Summary

Fixes the remaining error from #126: `Overlay Error: Status 400 when attempting download of: .../network-top-left/#0.png`.

`overlays/network-top-left/#0.png` exists in the repo — the 400 happens because the README and `exampleConfig.yml` showed `<<key>>` in the overlay URL templates, so the `#` in the `#0` key is sent as a raw URL fragment delimiter. Switching the network, studio, and streaming examples to `<<key_encoded>>` percent-encodes the key:

- `%230.png` → HTTP 200 ✅ (verified against raw.githubusercontent.com)
- also hardens keys containing `&` (the new U& family) and spaces (`Sky Sports`, `Showtime Networks`)

The audio and Common Sense examples keep `<<key>>` since those keys are plain slugs.

Anyone who copied the old config snippets needs to make the same one-word change on their side, so it's worth mentioning in the #126 thread once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp4GgszJpZm34XWVx5ry6D