### PR TITLE
Add Sofa Picks discovery collections for movies and series

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Screenshots now live in the individual guides to keep this README scannable.
 ## Movies & TV Enhancements
 This repository also ships battle-tested overlays and collections for standard Plex libraries.
 
+### Sofa Picks – Discovery Collections
+Self-maintaining "what should we watch tonight?" collections. They only surface things you *haven't* seen and refresh as you watch — Hidden Gems and Quick Watch Tonight for movies, Binge-Ready Shows and Limited Series for TV:
+
+```yaml
+libraries:
+  Movies:
+    collection_files:
+      - url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/collection_files/sofa_picks_movies.yaml
+  TV Shows:
+    collection_files:
+      - url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/collection_files/sofa_picks_series.yaml
+```
+
+The movie collections are pure Plex smart filters (zero external APIs); the series ones use TMDb status lookups via Kometa. Rating thresholds assume a 0-10 critic scale — tweak `.gte` values in the file to taste.
+
 ### Movies – Replacement Collections
 Swap out Plex’s defaults with smarter “New Releases” and “Old Movies Just Added” collections:
 

--- a/collection_files/sofa_picks_movies.yaml
+++ b/collection_files/sofa_picks_movies.yaml
@@ -1,0 +1,35 @@
+# Sofa Picks (Movies) — discovery collections for "what should we watch tonight?"
+#
+# Both collections are self-maintaining local Plex queries (no external API
+# needed) and remove titles as you watch them.
+#
+# Rating fields follow whatever your setup feeds Plex: critic_rating is
+# Metacritic/RT-critics (0-10), audience_rating is your audience source.
+# Tune the .gte thresholds to taste.
+#
+# Usage:
+#   collection_files:
+#     - url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/collection_files/sofa_picks_movies.yaml
+collections:
+  Hidden Gems:
+    smart_filter:
+      sort_by: random
+      limit: 100
+      all:
+        unplayed: true
+        critic_rating.gte: 7.5
+    summary: Critically acclaimed movies nobody here has watched yet. Refreshes as you watch — the gems you find disappear, new ones surface.
+    sort_title: "!015_Hidden_Gems"
+    visible_library: true
+
+  Quick Watch Tonight:
+    smart_filter:
+      sort_by: random
+      limit: 100
+      all:
+        unplayed: true
+        duration.lte: 100
+        audience_rating.gte: 7.0
+    summary: Well-rated movies under 100 minutes that you haven't seen. For evenings when a three-hour epic is not happening.
+    sort_title: "!016_Quick_Watch_Tonight"
+    visible_library: true

--- a/collection_files/sofa_picks_series.yaml
+++ b/collection_files/sofa_picks_series.yaml
@@ -1,0 +1,39 @@
+# Sofa Picks (Series) — discovery collections for "what should we start next?"
+#
+# Binge-Ready and Limited Series use TMDb status/type lookups (Kometa filters),
+# so membership refreshes on each Kometa run rather than live. Both drop shows
+# once someone starts watching them.
+#
+# critic_rating follows whatever your setup feeds Plex (0-10 scale) — tune the
+# .gte threshold to taste.
+#
+# Usage:
+#   collection_files:
+#     - url: https://raw.githubusercontent.com/s0len/meta-manager-config/main/collection_files/sofa_picks_series.yaml
+collections:
+  Binge-Ready Shows:
+    plex_search:
+      all:
+        unplayed: true
+        critic_rating.gte: 7.5
+    filters:
+      tmdb_status:
+        - ended
+        - canceled
+    collection_order: random
+    sync_mode: sync
+    summary: Complete, well-rated shows nobody here has started. The whole story is already told — no waiting a year for the next season.
+    sort_title: "!015_Binge_Ready"
+    visible_library: true
+
+  Limited Series:
+    plex_search:
+      all:
+        unplayed: true
+    filters:
+      tmdb_type: miniseries
+    collection_order: random
+    sync_mode: sync
+    summary: Miniseries you haven't seen — a complete story in a handful of episodes. Perfect single-weekend commitments.
+    sort_title: "!016_Limited_Series"
+    visible_library: true


### PR DESCRIPTION
## Summary

Four drop-in, self-maintaining discovery collections aimed at the "browsing the sofa for something new to watch" moment. All of them only show **unwatched** titles and refresh as you watch:

**`collection_files/sofa_picks_movies.yaml`** (pure Plex smart filters, no external APIs):
- **Hidden Gems** — unplayed + critic rating ≥ 7.5, random order
- **Quick Watch Tonight** — unplayed, under 100 minutes, audience rating ≥ 7.0

**`collection_files/sofa_picks_series.yaml`** (TMDb lookups via Kometa filters):
- **Binge-Ready Shows** — well-rated, fully ended/canceled shows nobody has started
- **Limited Series** — unwatched miniseries

README gets a new "Sofa Picks" section with usage snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp4GgszJpZm34XWVx5ry6D